### PR TITLE
fix(go): repair the Go build cache on ARC runners

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -39,11 +39,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # ARC runners start from a clean container, so $GOMODCACHE and $GOCACHE do not
+      # exist yet. actions/cache resolves its paths via glob and aborts the restore
+      # ("Some specified paths were not resolved") when they are missing, which
+      # silently disabled the Go cache on every run. Create them up front.
+      - name: Prepare Go cache dirs
+        run: mkdir -p ~/go/pkg/mod ~/.cache/go-build
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ inputs.go_version }}
-          cache-dependency-path: ${{ inputs.path }}/go.sum
+          cache: false
+
+      # Restored separately instead of via setup-go's `cache: true`: setup-go only
+      # looks up an exact go.sum hash and has no restore-keys fallback, so every
+      # dependency bump rebuilt the whole module graph from scratch.
+      - name: Restore Go build & module cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
+            go-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build
         env:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -44,11 +44,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # ARC runners start from a clean container, so $GOMODCACHE and $GOCACHE do not
+      # exist yet. actions/cache resolves its paths via glob and aborts the restore
+      # ("Some specified paths were not resolved") when they are missing, which
+      # silently disabled the Go cache on every run. Create them up front.
+      - name: Prepare Go cache dirs
+        run: mkdir -p ~/go/pkg/mod ~/.cache/go-build
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ inputs.go_version }}
-          cache-dependency-path: ${{ inputs.path }}/go.sum
+          cache: false
+
+      # Restored separately instead of via setup-go's `cache: true`: setup-go only
+      # looks up an exact go.sum hash and has no restore-keys fallback, so every
+      # dependency bump rebuilt the whole module graph from scratch.
+      - name: Restore Go build & module cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
+            go-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Test
         env:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,11 +39,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # ARC runners start from a clean container, so $GOMODCACHE and $GOCACHE do not
+      # exist yet. actions/cache resolves its paths via glob and aborts the restore
+      # ("Some specified paths were not resolved") when they are missing, which
+      # silently disabled the Go cache on every run. Create them up front.
+      - name: Prepare Go cache dirs
+        run: mkdir -p ~/go/pkg/mod ~/.cache/go-build
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ inputs.go_version }}
-          cache-dependency-path: ${{ inputs.path }}/go.sum
+          cache: false
+
+      # Restored separately instead of via setup-go's `cache: true`: setup-go only
+      # looks up an exact go.sum hash and has no restore-keys fallback, so every
+      # dependency bump rebuilt the whole module graph from scratch.
+      - name: Restore Go build & module cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
+            go-${{ runner.os }}-${{ runner.arch }}-
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0


### PR DESCRIPTION
## Problem

The Go module and build caches have never worked in `go-test.yml`, `golangci-lint.yml` or `go-build.yml`. Every run of every consumer started from a completely cold cache.

The ephemeral ARC container runners start without `$GOMODCACHE` and `$GOCACHE`. `actions/cache` resolves its `path:` entries via glob and gives up when they are missing, so the restore aborted before the key was even checked:

```
[command]go env GOMODCACHE   → /home/runner/go/pkg/mod
[command]go env GOCACHE      → /home/runner/.cache/go-build
##[warning]Restore cache failed: Some specified paths were not resolved, unable to cache dependencies.
```

On GitHub-hosted runners those directories are pre-created, which is why this never surfaced there.

Measured on mogenius-operator CI run [32343754108](https://github.com/mogenius/mogenius-operator/actions/runs/32343754108):

| | |
|---|---|
| Modules downloaded per run | **168**, on every run — including commits that do not touch `go.sum` |
| `go test` step | 5m37s |
| …of which download + compile | **4m39s** |
| Sum of all actual test runtimes | **≈ 1.0 second** |
| `golangci-lint` step | 3m42s |
| Its only cache hit | 156 KB — the golangci analysis cache, not the Go build cache |

## Fix

1. **`mkdir -p ~/go/pkg/mod ~/.cache/go-build` before `setup-go`.** This is the actual bug fix; the cache works again.
2. **Explicit `actions/cache` step with `restore-keys`, `cache: false` on setup-go.** `setup-go` restores on an exact `go.sum` hash only and exposes no `restore-keys`, so every Renovate dependency bump meant a full cold rebuild. The two prefix fallbacks keep most of the build cache warm across bumps.
3. **`go_version` is part of the cache key**, so a Go upgrade invalidates stale build objects rather than mixing them.

## Blast radius

Consumers are `mogenius-operator`, `mocli` and `EchoFail`. All three pin `@b5293d66` (v1.7.4), so nothing changes for them until a release is cut and Renovate bumps the SHA.

`go-build.yml` carries the same fix — same bug, and it sits on the release path.

## Verifying after the bump

In the first run on the new SHA, the `Set up Go` section should no longer contain the `Restore cache failed` warning, and should show `Cache saved with key: go-Linux-X64-stable-<hash>`. The **second** run is the meaningful one — the first only populates the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)