### PR TITLE
fix: unblock Go 1.27 lint and repair the cache key for subdir paths

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -61,7 +61,12 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+          # `path` is the directory the tool runs in, which is not always the module
+          # root: a repo may keep go.mod at the top level and point the job at a
+          # subdirectory. hashFiles returns an empty string for a file that does not
+          # exist, which would collapse the key to a constant that never invalidates,
+          # so fall back to the repo-root go.sum.
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) || hashFiles('go.sum') }}
           restore-keys: |
             go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
             go-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -66,7 +66,12 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+          # `path` is the directory the tool runs in, which is not always the module
+          # root: a repo may keep go.mod at the top level and point the job at a
+          # subdirectory. hashFiles returns an empty string for a file that does not
+          # exist, which would collapse the key to a constant that never invalidates,
+          # so fall back to the repo-root go.sum.
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) || hashFiles('go.sum') }}
           restore-keys: |
             go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
             go-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ on:
       golangci_lint_version:
         description: 'golangci-lint version'
         required: false
-        default: 'v2.12.2' # renovate: datasource=github-releases depName=golangci/golangci-lint
+        default: 'v2.13.1' # renovate: datasource=github-releases depName=golangci/golangci-lint
         type: string
       args:
         description: 'Extra arguments passed to golangci-lint run'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -61,7 +61,12 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+          # `path` is the directory the tool runs in, which is not always the module
+          # root: a repo may keep go.mod at the top level and point the job at a
+          # subdirectory. hashFiles returns an empty string for a file that does not
+          # exist, which would collapse the key to a constant that never invalidates,
+          # so fall back to the repo-root go.sum.
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-${{ hashFiles(format('{0}/go.sum', inputs.path)) || hashFiles('go.sum') }}
           restore-keys: |
             go-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go_version }}-
             go-${{ runner.os }}-${{ runner.arch }}-


### PR DESCRIPTION
Two independent CI defects that surfaced together when `setup-go`'s `stable` channel moved to Go 1.27.

## 1. golangci-lint default v2.12.2 cannot analyse Go 1.27

v2.12.2 bundles `honnef.co/go/tools v0.7.0`, whose IR builder panics walking the Go 1.27 stdlib:

```
[runner] Panic: buildir: package "poll" (isInitialPkg: false, needAnalyzeSource: true): unexpected expr: *ast.KeyValueExpr
Running error: can't run linter goanalysis_metalinter
```

Consumers see this as bogus typecheck findings — `undefined: rand`, `method must have no type parameters` — and a red lint job.

**This currently blocks every Go repo in the org that takes the default version.** In `mogenius-operator`, `main` and every open Renovate PR have been red since the Go 1.27 rollout; the only green branch is one that pins the version by hand.

Bumped the default to v2.13.1 (`honnef.co/go/tools 0.8.0`). Verified against mogenius-operator on Go 1.27.0: v2.12.2 panics, v2.13.1 reports 0 issues.

## 2. Cache key collapses when the module root is above `path`

`key: ...-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}` assumes `path` is the module root. It isn't always — a repo may keep `go.mod` at the top level and point the job at a subdirectory. `mogenius-operator` passes `path: src` to `go-test.yml` while its `go.mod`/`go.sum` sit at the repo root.

`hashFiles` returns `''` for a pattern matching nothing, so in that layout the key becomes the constant `go-Linux-X64-stable-` — written once, never invalidated. The cache goes stale silently and every run rebuilds the drift, which is exactly what the explicit cache step in #v1.7.5 was meant to eliminate.

Falls back to the repo-root `go.sum`. Repos where the module root and `path` coincide are unaffected: the first pattern matches and short-circuits.

## Why this matters beyond the lint job

In mogenius-operator this combination cost a self-hosted runner. With the cache cold, the lint job spent 27 minutes rebuilding the full dependency tree, then died in `Post Set up Go` while writing the multi-GB cache — `The self-hosted runner lost communication with the server`. The lint step itself had already passed. A rerun against a warm cache finished the same commit in 9m8s.

## Verification

- `actionlint` clean on all three modified workflows (the `||` fallback expression validates).
- All workflow files parse as YAML.
- golangci-lint v2.12.2 vs v2.13.1 reproduced locally against mogenius-operator on Go 1.27.0.

## Follow-up

Once released, `mogenius-operator` needs its reusable-workflow pin bumped from v1.7.4 — it predates the ARC cache repair in v1.7.5 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)